### PR TITLE
Link zur JHG-Freusburg URL: Fix für 404 und HTTPS

### DIFF
--- a/content/events/2024-01-03-freizeit.md
+++ b/content/events/2024-01-03-freizeit.md
@@ -11,7 +11,7 @@ draft: false
 
 Es ist soweit.
 Wir möchten uns mit euch für ein paar Tage dem Alltag entziehen
-und uns gemeinsam in der [Jugendherberge Freusburg](http://www.jugendherberge.de/de-de/jugendherbergen/freusburg359/portraet) dem Pen & Paper spielen widmen.
+und uns gemeinsam in der [Jugendherberge Freusburg](https://www.jugendherberge.de/jugendherbergen/freusburg/) dem Pen & Paper spielen widmen.
 
 Es gibt Spielrunden verschiedenster Rollenspielsysteme, darunter normalerweise:
 


### PR DESCRIPTION
Der Link zur Freusburg landete auf einer Fehlerseite (`404`), da sich anscheinend die Seitenstruktur vom DJH geändert hat.

Dieser Patch ändert der Pfad zu einer aktuell funktionierenden Seite, und nutzt `https` (statt vorher `http`).